### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,9 @@
         "tgmpa/tgm-plugin-activation": "^2.6.1"
     },
     "autoload": {
+        "classmap": [
+            "wds-shortcodes.php",
+            "includes/"
     },
     "minimum-stability": "dev"
 }

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "classmap": [
             "wds-shortcodes.php",
             "includes/"
+            ]
     },
     "minimum-stability": "dev"
 }

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
         "tgmpa/tgm-plugin-activation": "^2.6.1"
     },
     "autoload": {
-        "files": ["wds-shortcodes.php"]
     },
     "minimum-stability": "dev"
 }

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": ">5.2",
         "jtsternberg/shortcode-button": "^v1.0.7",
-        "tgmpa/tgm-plugin-activation": "2.5.2"
+        "tgmpa/tgm-plugin-activation": "^2.6.1"
     },
     "minimum-stability": "dev"
 }

--- a/composer.json
+++ b/composer.json
@@ -22,5 +22,8 @@
         "jtsternberg/shortcode-button": "^v1.0.7",
         "tgmpa/tgm-plugin-activation": "^2.6.1"
     },
+    "autoload": {
+        "files": ["wds-shortcodes.php"]
+    },
     "minimum-stability": "dev"
 }

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,5 @@
         "jtsternberg/shortcode-button": "^v1.0.7",
         "tgmpa/tgm-plugin-activation": "2.5.2"
     },
-    "autoload": {
-        "files": ["vendor/jtsternberg/shortcode-button/shortcode-button.php"]
-    },
     "minimum-stability": "dev"
 }


### PR DESCRIPTION
If a project uses shortcode-button as a dependency, wds-shortcodes currently breaks because it hard codes the path it expects shortcode-button to reside at, namely:

`/vendor/webdevstudios/wds-shortcodes/vendor/jtsternberg/shortcode-button/shortcode-button.php`

Whereas the shortcode-button dependency will actually be installed at:

`/vendor/jtsternberg/shortcode-button/shortcode-button.php`

Removing the autoload lines relating to shortcode-button will resolve this issue, Composer automatically handles ensuring wds-shortcodes has access to its dependencies.